### PR TITLE
fix: update project date size for phones

### DIFF
--- a/css/phone-styles.css
+++ b/css/phone-styles.css
@@ -65,26 +65,47 @@
     }
     .projects-section .left::after, .projects-section .right::after {
         width: 14%;
-        font-size: 1.4vw;
+        font-size: 2.6vw;
         left: calc(-8.5vw - 21px);
-        padding-top: 3px;
-        padding-left: 3px;
+        padding-left: 4px;
     }
-    .projects-section .right::after {
-        padding-left: 2px;
+    .projects-section .left::before, .projects-section .right::before {
+        content: "";
+        text-align: center;
+        position: absolute;
+        top: 43.5%;
+        width: 14%;
+        font-size: 2.7vw;
+        left: calc(-8.5vw - 21px);
+        padding-left: 4px;
+    }
+    .projects-section .right::after, .projects-section .right::before {
+        padding-left: 5px;
         padding-right: 2px;
     }
     .projects-section #project-portfolioWebsite::after {
-        content: "Oct 2024";
+        content: "2024";
     }
     .projects-section #project-platformShooter::after {
-        content: "Aug 2024";
+        content: "2024";
     }
     .projects-section #project-autoMate::after {
-        content: "May 2022";
+        content: "2022";
     }
     .projects-section #project-snakeSFML::after {
-        content: "Sep 2020";
+        content: "2020";
+    }
+    .projects-section #project-portfolioWebsite::before {
+        content: "Oct";
+    }
+    .projects-section #project-platformShooter::before {
+        content: "Aug";
+    }
+    .projects-section #project-autoMate::before {
+        content: "May";
+    }
+    .projects-section #project-snakeSFML::before {
+        content: "Sep";
     }
     .projects-section #projects-split-right {
         padding-top: calc(66vw * 5/6);


### PR DESCRIPTION
Update project date for phone screens to show above and below the lines branching off the timeline. Allows for increased Font size and easier to see on smaller screens.

Closes #8 